### PR TITLE
Auto ports forwarding

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,5 +1,5 @@
 # Changes here will be overwritten by Copier; NEVER EDIT MANUALLY
-_commit: 4.1.0b5
+_commit: 4.1.0b6
 _src_path: gh:epics-containers/ioc-template
 description: The Simulation AreaDetector generic IOC.
 git_platform: github.com

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -46,21 +46,6 @@
         // Make sure SELinux does not disable write access to host filesystems like tmp
         "--security-opt=label=disable"
     ],
-    "appPort": [
-        // Expose Channel Access ports on the host's loopback interface
-        // Note: set all three environment variables below to unique values
-        // in order to a second devcontainer on the same host.
-        //
-        // Then use e.g. EPICS_CA_ADDR_LIST="127.0.0.1:5064 127.0.0.1:6064"
-        // for clients to connect to multiple devcontainers' PVs.
-        //
-        "127.0.0.1:${localEnv:EPICS_CA_SERVER_PORT:5064}:${localEnv:EPICS_CA_SERVER_PORT:5064}/udp",
-        "127.0.0.1:${localEnv:EPICS_CA_SERVER_PORT:5064}:${localEnv:EPICS_CA_SERVER_PORT:5064}",
-        "127.0.0.1:${localEnv:EPICS_CA_REPEATER_PORT:5065}:${localEnv:EPICS_CA_REPEATER_PORT:5065}",
-        //
-        // Expose the PVA name server port on all host interfaces
-        "${localEnv:EPICS_PVA_SERVER_PORT:5075}:${localEnv:EPICS_PVA_SERVER_PORT:5075}"
-    ],
     // Mount the parent of the project folder so we can access peer projects
     "workspaceMount": "source=${localWorkspaceFolder}/..,target=/workspaces,type=bind",
     // mount in other useful files from the host

--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ This repository includes a developer container configuration for Visual Studio C
 
 ## Channel Access
 
-The developer container exposes channel access ports on the loopback interface. If you have channel access clients running on the host machine, you can connect to the IOC by setting the `EPICS_CA_ADDR_LIST` environment variable as follows:
+The vscode developer container auto forwards the channel access ports on the loopback interface. If you have channel access clients running on the host machine, you can connect to the IOC by setting the `EPICS_CA_NAME_SERVERS` environment variable as follows:
 
 ```bash
-export EPICS_CA_ADDR_LIST=127.0.0.1
+export EPICS_CA_NAME_SERVERS=127.0.0.1:5064
 caget IOCNAME:PVNAME
 ```

--- a/opi/settings.ini
+++ b/opi/settings.ini
@@ -6,6 +6,7 @@
 org.phoebus.pv.ca/addr_list=127.0.0.1
 org.phoebus.pv.ca/server_port=5064
 org.phoebus.pv.ca/repeater_port=5065
+org.phoebus.pv.ca/name_servers=127.0.0.1:5064
 # point at local host for pvAccess name server
-org.phoebus.pv.pva/epics_pva_name_servers=127.0.0.1
+org.phoebus.pv.pva/epics_pva_name_servers=127.0.0.1:5064
 org.phoebus.pv.pva/server_port=5075


### PR DESCRIPTION
This change means:

- that the devcontainer launch will never fail due to 'port in use'
- vscode will auto forward the port outside of the container network when you start the IOC inside
- because no UDP port is exposed by auto port forward, we must use EPICS_CA_NAME_SERVERS=127.0.0.1:5064 (or alternative port as needed) to access CA
- this also supports PVA through EPICS_PVA_NAME_SERVERS
- a second devcontainer can run its IOC simultaneously - random ports will be selected by the IOC
