### PR TITLE
Add support for local socket console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -72,7 +72,8 @@ COPY --from=runtime_prep /assets /
 # install runtime system dependencies, collected from install.sh scripts
 RUN ibek support apt-install-runtime-packages --skip-non-native
 
-CMD ["bash", "-c", "${IOC}/start.sh"]
+# launch the startup script with stdio-expose to allow console connections
+CMD ["bash", "-c", "stdio-expose ${IOC}/start.sh"]
 
 ##### stage that fully configures the example IOC ##################
 

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -169,7 +169,7 @@ fi
 if [[ ${EPICS_TARGET_ARCH} == "linux-x86_64" ]] ; then
     # Execute the IOC binary and pass the startup script as an argument
     # wrap it with expose-stdio - TODO ADD THIS TO ioc-template
-    exec expose-stdio "${IOC}/bin/linux-x86_64/ioc ${final_ioc_startup}"
+    exec stdio-expose "${IOC}/bin/linux-x86_64/ioc ${final_ioc_startup}"
 else
     # for not native architectures use the appropriate python package
     if [[ -f ${CONFIG_DIR}/proxy-start.sh ]]; then

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -168,7 +168,8 @@ fi
 
 if [[ ${EPICS_TARGET_ARCH} == "linux-x86_64" ]] ; then
     # Execute the IOC binary and pass the startup script as an argument
-    exec ${IOC}/bin/linux-x86_64/ioc ${final_ioc_startup}
+    # wrap it with expose-stdio - TODO ADD THIS TO ioc-template
+    exec expose-stdio "${IOC}/bin/linux-x86_64/ioc ${final_ioc_startup}"
 else
     # for not native architectures use the appropriate python package
     if [[ -f ${CONFIG_DIR}/proxy-start.sh ]]; then

--- a/ioc/start.sh
+++ b/ioc/start.sh
@@ -169,7 +169,7 @@ fi
 if [[ ${EPICS_TARGET_ARCH} == "linux-x86_64" ]] ; then
     # Execute the IOC binary and pass the startup script as an argument
     # wrap it with expose-stdio - TODO ADD THIS TO ioc-template
-    exec stdio-expose "${IOC}/bin/linux-x86_64/ioc ${final_ioc_startup}"
+    ${IOC}/bin/linux-x86_64/ioc ${final_ioc_startup}
 else
     # for not native architectures use the appropriate python package
     if [[ -f ${CONFIG_DIR}/proxy-start.sh ]]; then

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-ibek==3.1.5
+ibek==3.2.1
 # to install direct from github during development in a branch
 # git+https://github.com/epics-containers/ibek.git@fix-extract-assets
+stdio-socket==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ibek==3.2.1
 # to install direct from github during development in a branch
 # git+https://github.com/epics-containers/ibek.git@fix-extract-assets
-stdio-socket==1.0.0
+stdio-socket==1.0.1

--- a/services/bl01t-ea-ioc-02/config/ioc.yaml
+++ b/services/bl01t-ea-ioc-02/config/ioc.yaml
@@ -96,18 +96,6 @@ entities:
     NELEMENTS: 1048576
     FTVL: UCHAR
 
-  - type: ffmpegServer.ffmpegStream
-    PORT: DET.MJPG
-    P: BL01T-DI-CAM-01
-    R: ":MJPG:"
-    NDARRAY_PORT: DET.PROC
-
-  - type: ffmpegServer.ffmpegFile
-    PORT: DET.MPEG
-    P: BL01T-DI-CAM-01
-    R: ":MPEG:"
-    NDARRAY_PORT: DET.PROC
-
   - type: ADCore.NDFileNetCDF
     PORT: DET.CDF
     P: BL01T-DI-CAM-01


### PR DESCRIPTION
- Add in the stdio-socket python package
- make the default entrypoint call start.sh using `stdio-expose`
- this means the command `console` inside the container will attach to the IOC console