### PR TITLE
only open index.bob in phoebus

### DIFF
--- a/opi/phoebus-launch.sh
+++ b/opi/phoebus-launch.sh
@@ -52,7 +52,6 @@ else
 
     settings="
     -resource /workspace/opi/auto-generated/index.bob
-    -resource /workspace/opi/bl01t-ea-ioc-02.bob
     -settings /tmp/settings.ini
     -server 2200
     "


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Phoebus launch flow to use a streamlined container configuration, removing an extra resource reference during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->